### PR TITLE
Feature: setup Glide for image loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.config
         }
+        debug {
+            // For quickly testing build with proguard, enable this
+            minifyEnabled false
+        }
     }
 
     lintOptions {
@@ -71,6 +75,12 @@ android {
 }
 
 dependencies {
+
+    kapt(
+            "android.arch.lifecycle:compiler:$arch_component_version",
+            "com.github.bumptech.glide:compiler:$glide_version"
+    )
+
     implementation(
             fileTree(dir: 'libs', include: ['*.jar']),
             "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version",
@@ -80,15 +90,13 @@ dependencies {
             "com.android.support:recyclerview-v7:$support_version",
             "com.android.support.constraint:constraint-layout:1.0.2",
 
-            "com.github.bumptech.glide:glide:$glide_version",
+            //"com.squareup.retrofit2:retrofit:$retrofit_version",
+            //"com.squareup.retrofit2:converter-gson:$retrofit_version",
+            //"com.squareup.retrofit2:adapter-rxjava2:$retrofit_version",
+            //"com.google.code.gson:gson:2.4",
 
-            "com.squareup.retrofit2:retrofit:$retrofit_version",
-            "com.squareup.retrofit2:converter-gson:$retrofit_version",
-            "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version",
-            "com.google.code.gson:gson:2.4",
-
-            "com.squareup.okhttp3:okhttp:$okhttp_version",
-            "com.squareup.okhttp3:logging-interceptor:$okhttp_version",
+            //"com.squareup.okhttp3:okhttp:$okhttp_version",
+            //"com.squareup.okhttp3:logging-interceptor:$okhttp_version",
 
             "io.reactivex.rxjava2:rxjava:$rxjava_version",
             "io.reactivex.rxjava2:rxandroid:$rxandroid_version",
@@ -100,6 +108,10 @@ dependencies {
             "com.google.dagger:dagger:$dagger_version",
             "com.android.support:multidex:1.0.1"
     )
+
+    implementation("com.github.bumptech.glide:glide:$glide_version") {
+        exclude group: "com.android.support"
+    }
 
     testImplementation(
             "junit:junit:$junit_version",

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,12 +42,6 @@ android {
         }
     }
 
-    lintOptions {
-        disable 'InvalidPackage'
-        checkReleaseBuilds false
-        abortOnError false
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,12 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Glide
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
+  **[] $VALUES;
+  public *;
+}
+-dontwarn com.bumptech.glide.load.resource.bitmap.VideoDecoder

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="template.nimbl3.android"
+<manifest package="template.nimbl3.ui"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -12,7 +12,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name="template.nimbl3.ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest package="template.nimbl3.android"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/template/nimbl3/di/AppGlideModule.kt
+++ b/app/src/main/java/template/nimbl3/di/AppGlideModule.kt
@@ -1,0 +1,7 @@
+package template.nimbl3.di
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+@GlideModule
+class MyAppGlideModule : AppGlideModule()

--- a/app/src/main/java/template/nimbl3/extension/ImageViewExtension.kt
+++ b/app/src/main/java/template/nimbl3/extension/ImageViewExtension.kt
@@ -1,0 +1,13 @@
+package template.nimbl3.extension
+
+import android.widget.ImageView
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import template.nimbl3.di.GlideApp
+
+fun ImageView.setImageUrl(url: String) {
+    GlideApp.with(context)
+            .load(url)
+            .diskCacheStrategy(DiskCacheStrategy.ALL)
+            .fitCenter()
+            .into(this)
+}

--- a/app/src/main/java/template/nimbl3/ui/MainActivity.kt
+++ b/app/src/main/java/template/nimbl3/ui/MainActivity.kt
@@ -1,12 +1,17 @@
-package template.nimbl3.android
+package template.nimbl3.ui
 
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.ImageView
+import template.nimbl3.extension.setImageUrl
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        findViewById<ImageView>(R.id.appCompatImageView)
+            .setImageUrl("http://www.monkeyuser.com/assets/images/2018/80-the-struggle.png")
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,10 +10,27 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="152dp"
+        android:layout_marginTop="8dp"
         android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/appCompatImageView"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/appCompatImageView"
+        android:layout_width="300dp"
+        android:layout_height="300dp"
+        android:layout_marginBottom="104dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="40dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.979"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/test/java/template/nimbl3/ui/ExampleUnitTest.kt
+++ b/app/src/test/java/template/nimbl3/ui/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package template.nimbl3.android
+package template.nimbl3.ui
 
 import org.junit.Test
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,22 +23,22 @@ allprojects {
 
     ext {
         // implementation dependencies version
-        arch_component_version = "1.0.0"
+        arch_component_version = '1.0.0'
         support_version        = '27.0.2'
         supportTestVersion     = '0.5'
 
         retrofit_version       = '2.3.0'
-        okhttp_version         = "3.7.0"
+        okhttp_version         = '3.7.0'
 
-        rxjava_version         = "2.1.4"
-        rxandroid_version      = "2.0.1"
+        rxjava_version         = '2.1.4'
+        rxandroid_version      = '2.0.1'
 
         dagger_version         = '2.11'
-        glide_version          = "3.6.1"
+        glide_version          = '4.6.1'
 
         // test dependencies version
         junit_version          = '4.12'
-        mockito_version        = "0.3.1"
+        mockito_version        = '0.3.1'
 
         test_runner_version    = '1.0.1'
     }


### PR DESCRIPTION
## What happened 🤔
Setting up Glide for image loading as this is an absolute need for every application.


## Insight 👀
- [x] Setting up Glide
- [x] Configure proguard for apk shrinking (retrofit is currently commented out for the sake of this purpose)
- [x] Make Glide loading verbose function as an extension function built-in ImageView


## PoW (a.k.a Proof Of Work)💪
- ImageView extension with Glide inner plugged usage is simple as:
```
imv.setImageUrl("url")
```

- With vs Without proguard application size: `1.18Mb vs 3.07Mb`
- Tested loading:

<img src="https://user-images.githubusercontent.com/13435717/37329680-44f24aec-26d1-11e8-9c36-a1ec7e74d708.png" width=200 /> 